### PR TITLE
Adds locale to fetch operations

### DIFF
--- a/src/learningPath/edit/tags/learningPathTagsActions.js
+++ b/src/learningPath/edit/tags/learningPathTagsActions.js
@@ -13,8 +13,8 @@ import { applicationError } from '../../../messages/messagesActions';
 export const setLearningPathTags = createAction('SET_LEARNING_PATH_TAGS');
 
 export function fetchLearningPathTags() {
-  return dispatch =>
-    fetchPathTags()
+  return (dispatch, getState) =>
+    fetchPathTags({}, getState().locale)
       .then(tags => dispatch(setLearningPathTags(tags)))
       .catch(err => dispatch(applicationError(err)));
 }

--- a/src/learningPath/learningPathActions.js
+++ b/src/learningPath/learningPathActions.js
@@ -51,8 +51,8 @@ function canAccessLearningPath(path, isEdit = false, dispatch) {
 }
 
 function fetchIsBasedOnPath(path) {
-  return dispatch =>
-    fetchPath({ pathId: path.isBasedOn })
+  return (dispatch, getState) =>
+    fetchPath({ pathId: path.isBasedOn }, getState().locale)
       .then(isBasedOnPath => {
         dispatch(
           setLearningPath({
@@ -65,8 +65,8 @@ function fetchIsBasedOnPath(path) {
 }
 
 export function fetchLearningPath(pathId, isEdit = false) {
-  return dispatch =>
-    fetchPath({ pathId })
+  return (dispatch, getState) =>
+    fetchPath({ pathId }, getState().locale)
       .then(path => {
         canAccessLearningPath(path, isEdit, dispatch);
         dispatch(setLearningPath(path));

--- a/src/learningPath/search/learningPathSearchActions.js
+++ b/src/learningPath/search/learningPathSearchActions.js
@@ -18,8 +18,8 @@ export const setLearningPathSearchResults = createAction(
 );
 
 function fetchIsBasedOnPath(path) {
-  return dispatch =>
-    fetchPath({ pathId: path.isBasedOn })
+  return (dispatch, getState) =>
+    fetchPath({ pathId: path.isBasedOn }, getState().locale)
       .then(isBasedOnPath => {
         dispatch(setLearningPathBasedOn({ isBasedOnPath, pathId: path.id }));
       })

--- a/src/learningPath/step/learningPathStepActions.js
+++ b/src/learningPath/step/learningPathStepActions.js
@@ -73,7 +73,7 @@ function canAccessLearningPathStep(pathId, step, isEdit = false, dispatch) {
 
 export function fetchLearningPathStep(pathId, stepId, isEdit = false) {
   return (dispatch, getState) => {
-    const { learningPath } = getState();
+    const { learningPath, locale } = getState();
 
     if (get(learningPath, 'id') === pathId) {
       const step = get(learningPath, 'learningsteps', []).find(
@@ -85,7 +85,7 @@ export function fetchLearningPathStep(pathId, stepId, isEdit = false) {
       }
     }
 
-    return fetchPathStep({ pathId, stepId })
+    return fetchPathStep({ pathId, stepId }, locale)
       .then(step => {
         dispatch(setLearningPathStep(step));
         canAccessLearningPathStep(pathId, step, isEdit, dispatch);

--- a/src/sources/helpers.js
+++ b/src/sources/helpers.js
@@ -118,8 +118,12 @@ export const authorizationHeader = token => `Bearer ${token}`;
 
 export function fetchAuthorized(path, method = 'GET') {
   const url = params => apiResourceUrl(formatUrl(path, params));
-  return (params = {}) =>
-    fetchAuth(url(params), { method }).then(resolveJsonOrRejectWithError);
+  return (params = {}, language) => {
+    const query = language ? `?language=${language}` : '';
+    return fetchAuth(`${url(params)}${query}`, { method }).then(
+      resolveJsonOrRejectWithError,
+    );
+  };
 }
 
 export function postAuthorized(path) {


### PR DESCRIPTION
 - [ ] Should now be possible to fetch learning paths in NN, NB or other languages supported. Can be checked at: `/learningpaths/45/step/361` (NN: `/nn/learningpaths/45/step/361`) (against test environment).