### PR TITLE
#1575: Enable 'trust proxy' for express

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -55,6 +55,8 @@ app.use(
   }),
 );
 
+app.enable('trust proxy');
+
 async function sendInternalServerError(req, res) {
   if (res.getHeader('Content-Type') === 'application/json') {
     res.status(INTERNAL_SERVER_ERROR).json('Internal server error');


### PR DESCRIPTION
connects to NDLANO/Issues#1575

The service mesh uses the `Host` header for outgoing requests. 
This means that the proxy cannot keep the `Host` header as ex "ndla.no".
Enabling `trust proxy` makes `req.hostname` use `X-Forwarded-Host` if it exists.