### PR TITLE
Fikser bildesøk slik at preview blir korrekt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nodemon": "1.18.3",
     "postcss": "8.4.19",
     "postcss-color-mod-function": "3.0.3",
+    "postcss-custom-media": "^9.0.1",
     "postcss-focus": "^5.0.1",
     "postcss-import": "^15.0.0",
     "postcss-loader": "^4.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,6 +10,7 @@ const postcssPresetEnv = require('postcss-preset-env');
 const postcssNested = require('postcss-nested');
 const postcssFocus = require('postcss-focus');
 const postcssColorMod = require('postcss-color-mod-function');
+const postcssCustomMedia = require('postcss-custom-media');
 const postcssImport = require('postcss-import');
 
 module.exports = {
@@ -18,6 +19,7 @@ module.exports = {
       glob: true,
     }),
     postcssColorMod(),
+    postcssCustomMedia(),
     postcssFocus(), // Add a :focus to every :hover
     postcssNested(),
     postcssPresetEnv(),

--- a/src/server/contentSecurityPolicy.js
+++ b/src/server/contentSecurityPolicy.js
@@ -22,6 +22,7 @@ const connectSrc = (() => {
     'https://*.ndla.no',
     'https://logs-01.loggly.com',
     'https://www.googleapis.com',
+    'https://stats.g.doubleclick.net',
     'https://*.clarity.ms',
   ];
   if (process.env.NODE_ENV === 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,6 +1421,21 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@csstools/css-parser-algorithms@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-1.0.0.tgz#63f0ecbb926abf92d6cd8d076663650ad340db8c"
+  integrity sha512-lPphY34yfV15tEXiz/SYaU8hwqAhbAwqiTExv5tOfc7QZxT70VVYrsiPBaX1osdWZFowrDEAhHe4H3JnyzbjhA==
+
+"@csstools/css-tokenizer@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-1.0.0.tgz#161c0c9b632952ee8c2f0a62eb479d736a5627ff"
+  integrity sha512-xdFjdQ+zqqkOsmee+kYRieZD9Cqh4hr01YBQ2/8NtTkMMxbtRX18MC50LX6cMrtaLryqmIdZHN9e16/l0QqnQw==
+
+"@csstools/media-query-list-parser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-1.0.0.tgz#17d08bfbcca677fc018e3dc3f54172a38c2fdca5"
+  integrity sha512-HsTj5ejI8NKKZ4IEd6kK2kQZA/JmIVlUV8+XvO/YS9ntrlYPnbmFT3rkqtbxOVfEafblYCNOpeNw1c+fKGkAqw==
+
 "@csstools/postcss-cascade-layers@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.1.1.tgz#8a997edf97d34071dd2e37ea6022447dd9e795ad"
@@ -12626,6 +12641,15 @@ postcss-custom-media@^8.0.2:
   integrity sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==
   dependencies:
     postcss-value-parser "^4.2.0"
+
+postcss-custom-media@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-9.0.1.tgz#b59ecc762cf5ba4b540434e0043f5b3ce8c80bce"
+  integrity sha512-CimS72gZZ0V4WPFg7t7EqFVLxJ0mqwAJSsuk+LNHSo9ApC7d/SuOr65sKrUY/D8locOh+3s4yO7IdqQ9cRSR7Q==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^1.0.0"
+    "@csstools/css-tokenizer" "^1.0.0"
+    "@csstools/media-query-list-parser" "^1.0.0"
 
 postcss-custom-properties@^12.1.10:
   version "12.1.10"


### PR DESCRIPTION
Fixes NDLANO/Issues#3391

Legger til postcss-custom-media som forsvant i razzle oppgradering. Fikser css for bildesøk.
Fikser også en csp-feil eg fikk.

Kan testes ved å redigere en læringssti, og legge til metabilde under rediger detaljer. Sjølv om du velger bilde 2,3 eller 4 skal forhåndsvisninga ligge til venstre i tabellen.